### PR TITLE
don't rely on pylab imports

### DIFF
--- a/Gauss_Markov.ipynb
+++ b/Gauss_Markov.ipynb
@@ -165,7 +165,7 @@
      "input": [
       "from  matplotlib.patches import Ellipse\n",
       "\n",
-      "fig, ax = subplots()\n",
+      "fig, ax = plt.subplots()\n",
       "fig.set_size_inches((6,6))\n",
       "ax.set_aspect(1)\n",
       "ax.plot(bb[0,:],bb[1,:],'g.')\n",
@@ -178,9 +178,9 @@
       "U,S,V = linalg.svd(bm_cov) \n",
       "\n",
       "err = np.sqrt((matrix(bm))*(bm_cov)*(matrix(bm).T))\n",
-      "theta = arccos(U[0,1])/pi*180\n",
+      "theta = np.arccos(U[0,1])/np.pi*180\n",
       "\n",
-      "ax.add_patch(Ellipse(bm,err*2/sqrt(S[0]),err*2/sqrt(S[1])\n",
+      "ax.add_patch(Ellipse(bm,err*2/np.sqrt(S[0]),err*2/np.sqrt(S[1])\n",
       "                       ,angle=theta,color='pink',alpha=0.5))\n",
       "\n",
       "plt.show()"


### PR DESCRIPTION
Hi, I needed to specify a few names a bit better to get this to run with "ipython notebook  --matplotlib=inline" which does not do "import *" on of the numpy and pylab namespace.
